### PR TITLE
chore(renovate): optimize configuration for terraform and security

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,49 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ]
+    "config:best-practices",
+    ":pinDigests",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "dependencyDashboard": true,
+  "labels": ["dependencies"],
+  "assignees": ["masarakki"],
+  "stabilityDays": 3,
+  "rangeStrategy": "pin",
+  "packageRules": [
+    {
+      "description": "Group all non-major dependencies and enable automerge",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "non-major dependencies",
+      "groupSlug": "non-major",
+      "automerge": true
+    },
+    {
+      "description": "Disable automerge for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "Exempt reliable packages from stability days",
+      "matchPackagePatterns": [
+        "^actions/",
+        "^aws-actions/",
+        "^hashicorp/"
+      ],
+      "matchManagers": ["terraform-version"],
+      "stabilityDays": 0
+    },
+    {
+      "description": "Group all GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group all Terraform updates",
+      "matchManagers": ["terraform", "terraform-version"],
+      "groupName": "terraform"
+    }
+  ],
+  "timezone": "Asia/Tokyo"
 }


### PR DESCRIPTION
## Summary
Optimized Renovate configuration to align with modern best practices, focusing on security and reducing maintenance noise.

## Key Changes
- **Best Practices**: Switched to `config:best-practices` for more robust defaults.
- **Security**: Enabled SHA pinning for GitHub Actions and Docker images to mitigate supply chain risks.
- **Stability Delay**: Implemented a 3-day stability delay for non-trusted packages.
- **Trusted Packages**: Exempted official `actions/*`, `aws-actions/*`, and `hashicorp/*` (plus Terraform engine) from the stability delay.
- **Auto-merge**: Enabled auto-merge for non-major updates (minor, patch, pin, digest) to reduce manual work.
- **Version Control**: Set `rangeStrategy: pin` to ensure all version updates are tracked through Renovate PRs.
- **Management**: Added @masarakki as the default assignee and enabled the Dependency Dashboard.